### PR TITLE
HOTFIX: (master) Safer NPM install commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: npm ci
+      - run: npm ci --ignore-scripts --no-audit
       - run: npm test
       - run: npm audit --audit-level=high

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,14 @@
         "fs-extra": "^11.3.0",
         "kleur": "^4.1.5",
         "prompts": "^2.4.2",
-        "replace-in-file": "^8.4.0",
+        "replace-in-file": "^9.0.0",
         "simple-git": "^3.36.0"
       },
       "bin": {
         "create-startr": "index.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@kwsites/file-exists": {
@@ -100,9 +103,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -112,12 +115,12 @@
       }
     },
     "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-6.0.0.tgz",
+      "integrity": "sha512-2uNTXIuTTxk7ciZgAU1BQcgnchcG0xXnrs6jzkQfj9SsRa9M2s5zE8WT96hS6KmG4MzWHSrvH43DF1m4XRkrFg==",
       "license": "MIT",
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -323,20 +326,20 @@
       }
     },
     "node_modules/replace-in-file": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-8.4.0.tgz",
-      "integrity": "sha512-D28k8jy2LtUGbCzCnR3znajaTWIjJ/Uee3UdodzcHRxE7zn6NmYW/dcSqyivnsYU3W+MxdX6SbF28NvJ0GRoLA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-9.0.0.tgz",
+      "integrity": "sha512-ACFXyc5ninRlHSVw8ZRht0Fd/BKoje8mpbIDZjbOU/LCaaoZzD9uo3zDQNkULDhcrvhXyL38FCcF1D2SiHM6Vg==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.6.2",
-        "glob": "^13.0.0",
-        "yargs": "^18.0.0"
+        "chalk": "^6.0.0",
+        "glob": "^13.0.6",
+        "yargs": "^18.1.0"
       },
       "bin": {
-        "replace-in-file": "bin/cli.js"
+        "replace-in-file": "dist/bin/cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/simple-git": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fs-extra": "^11.3.0",
     "kleur": "^4.1.5",
     "prompts": "^2.4.2",
-    "replace-in-file": "^8.4.0",
+    "replace-in-file": "^9.0.0",
     "simple-git": "^3.36.0"
   },
   "bin": {


### PR DESCRIPTION
Upgrade `replace-in-file` package to fix: https://github.com/globeandmail/startr-cli/security/dependabot/36

We should be using `npm ci --ignore-scripts --no-audit` in our CI/CD pipelines, to prevent malicious postinstall scripts from running. 

The `--no-audit` speeds up the install a bit. Since NPM doesn't audit the packages. Which isn't useful in CI, as developers don't tend to check the CI logs for the audit results. They will see them when developing locally, via `npm install`.

## References:
- https://docs.npmjs.com/cli/v11/commands/npm-ci
- https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan#cicd-pipelines-2
