### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/globeandmail/startr-cli/security/code-scanning/1](https://github.com/globeandmail/startr-cli/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml`, preferably at the workflow root so it applies to all jobs unless overridden. For this CI workflow, `contents: read` is the minimal and appropriate permission based on current steps (`checkout`, setup Node, run npm commands). This preserves existing functionality while hardening token scope and documenting intended access.

Change region:
- File: `.github/workflows/ci.yml`
- Insert `permissions:` after the `on:` trigger block and before `jobs:`.

No new imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
